### PR TITLE
Intel compiler issue for IsntropicVortex

### DIFF
--- a/source/IO/IOMain/IO_output.F90
+++ b/source/IO/IOMain/IO_output.F90
@@ -395,8 +395,10 @@ subroutine IO_output( simTime, dt, nstep, nbegin, endRun, outputType)
  
     
   !Logic is being moved out of IO_writeParticles.  When it is called, it had better be used!
+!! Devnote :: preprocessors because amrex particles are being handled through amrex grid
+#ifndef FLASH_GRID_AMREX
   if(outputParticleFile) call IO_writeParticles( .false.)
-
+#endif
   
 
   !------------------------------------------------------------------------------

--- a/source/IO/IOMain/IO_outputFinal.F90
+++ b/source/IO/IOMain/IO_outputFinal.F90
@@ -48,7 +48,10 @@ subroutine IO_outputFinal()
    
      call IO_writePlotfile(.true.)
      
+!! Devnote :: preprocessors because amrex particles are being handled through amrex grid
+#ifndef FLASH_GRID_AMREX
      call IO_writeParticles(.false.)
+#endif
   end if
 
   io_outputInStack = .false.

--- a/source/IO/IOMain/IO_outputInitial.F90
+++ b/source/IO/IOMain/IO_outputInitial.F90
@@ -81,8 +81,10 @@ subroutine IO_outputInitial( nbegin, initialSimTime)
 
      if( io_restart) forcePlotfile = .true.
      call IO_writePlotfile(forcePlotfile)
-
+!! Devnote :: preprocessors because amrex particles are being handled through amrex grid
+#ifndef FLASH_GRID_AMREX
      call IO_writeParticles( .false.)
+#endif
   else
      io_justCheckpointed = .false.
   end if

--- a/source/IO/IOMain/IO_writeCheckpoint.F90
+++ b/source/IO/IOMain/IO_writeCheckpoint.F90
@@ -131,7 +131,10 @@ subroutine IO_writeCheckpoint()
   !if particles are  not included in this simulation this
   !function will be empty
 
+!! Devnote :: preprocessors because amrex particles are being handled through amrex grid
+#ifndef FLASH_GRID_AMREX
   call IO_writeParticles( .true.)
+#endif
 
   call IO_writeUserArray()
 

--- a/source/IO/IOParticles/IO_writeParticles.F90
+++ b/source/IO/IOParticles/IO_writeParticles.F90
@@ -96,7 +96,7 @@ subroutine IO_writeParticles( particlesToCheckpoint)
   logical restart
   logical :: forceParticleFile
 
-  real :: currentRedshift
+  real :: currentRedshift = 0.
   integer :: nstep
 
 

--- a/source/Simulation/SimulationMain/IsentropicVortex/Config
+++ b/source/Simulation/SimulationMain/IsentropicVortex/Config
@@ -61,6 +61,12 @@ PARAMETER nx_subint        INTEGER 10
 D ny_subint number of subintervals along JAXIS
 PARAMETER ny_subint        INTEGER 10
 
+D Four parameter to initialize the domain properly 
+PARAMETER diDomain             REAL    0.0
+PARAMETER djDomain             REAL    0.0
+PARAMETER imidDomain             REAL    0.0
+PARAMETER jmidDomain             REAL    0.0
+
 PARTICLEPROP pdens		REAL
 PARTICLEMAP TO pdens FROM VARIABLE dens
 #! To enable particle tracking of temperature, enable the

--- a/source/Simulation/SimulationMain/IsentropicVortex/Simulation_init.F90
+++ b/source/Simulation/SimulationMain/IsentropicVortex/Simulation_init.F90
@@ -49,6 +49,20 @@ subroutine Simulation_init()
 
   real :: entropy, dst, dsd
   call Driver_getMype(MESH_COMM,sim_meshMe)
+
+!! Initalize these variables. Caution: If uninitialized vars are not set in flash.par
+!! then some compilers (e.g. intel) that do not autoinitialize throw floating point error 
+!! at first instance
+  sim_xctrTrue = 0.
+  sim_yctrTrue = 0.
+  sim_diDomain = 0.
+  sim_djDomain = 0.
+  sim_imidDomain = 0.
+  sim_jmidDomain = 0.
+  sim_nxSubint = 1
+  sim_nySubint = 1
+  sim_vortexStrength =0.
+
   call RuntimeParameters_get( 'gamma', sim_gamma)
   call RuntimeParameters_get( 'u_ambient',sim_uAmbient  )
   call RuntimeParameters_get( 'v_ambient',sim_vAmbient  )

--- a/source/Simulation/SimulationMain/IsentropicVortex/Simulation_init.F90
+++ b/source/Simulation/SimulationMain/IsentropicVortex/Simulation_init.F90
@@ -50,18 +50,6 @@ subroutine Simulation_init()
   real :: entropy, dst, dsd
   call Driver_getMype(MESH_COMM,sim_meshMe)
 
-!! Initalize these variables. Caution: If uninitialized vars are not set in flash.par
-!! then some compilers (e.g. intel) that do not autoinitialize throw floating point error 
-!! at first instance
-  sim_xctrTrue = 0.
-  sim_yctrTrue = 0.
-  sim_diDomain = 0.
-  sim_djDomain = 0.
-  sim_imidDomain = 0.
-  sim_jmidDomain = 0.
-  sim_nxSubint = 1
-  sim_nySubint = 1
-  sim_vortexStrength =0.
 
   call RuntimeParameters_get( 'gamma', sim_gamma)
   call RuntimeParameters_get( 'u_ambient',sim_uAmbient  )
@@ -85,6 +73,10 @@ subroutine Simulation_init()
   call RuntimeParameters_get( 'rho_ambient', rhoAmbient  )
   call RuntimeParameters_get( 'p_ambient',   pAmbient  )
   
+  call RuntimeParameters_get( 'diDomain', sim_diDomain)
+  call RuntimeParameters_get( 'djDomain', sim_djDomain)
+  call RuntimeParameters_get( 'imidDomain', sim_imidDomain)
+  call RuntimeParameters_get( 'jmidDomain', sim_jmidDomain)
   
 !   Some checking of the inputs:
   if ( NDIM == 1 ) then

--- a/source/Simulation/SimulationMain/IsentropicVortex/flash.par
+++ b/source/Simulation/SimulationMain/IsentropicVortex/flash.par
@@ -62,6 +62,11 @@ ymax            = 10.0
 nx_subint       = 1
 ny_subint       = 1
 
+imidDomain	= 0.
+jmidDomain	= 0.
+diDomain	= 0.
+djDomain	= 0.
+
 geometry        = "cartesian"
 
 xl_boundary_type = "periodic"

--- a/source/Simulation/SimulationMain/IsentropicVortex/flash.par.amr
+++ b/source/Simulation/SimulationMain/IsentropicVortex/flash.par.amr
@@ -1,0 +1,115 @@
+#  Runtime parameter file for the isentropic vortex problem
+
+#               AMR parameters
+
+lrefine_max     = 4
+lrefine_min     = 1
+refine_var_1     = "dens"
+
+pt_numX	= 10
+pt_numY	= 10
+
+pt_maxPerProc = 100
+
+useParticles = .true.
+
+pt_initialXMin = 0.0
+pt_initialXMax = 10.0
+pt_initialYMin = 0.0
+pt_initialYMax = 10.0
+pt_initialZMin = 0.0
+pt_initialZMax = 10.0
+
+
+#		simulation parameters
+
+basenm          = "isentropic_vortex_"
+log_file        = "isentropic_vortex.log"
+restart         = .false.
+checkpointFileIntervalTime = 0.0
+checkpointFileIntervalStep = 20
+checkpointFileNumber = 0	
+
+nend            = 1000
+tmax            = 10.
+
+#nblockx		= 2
+#nblocky		= 2
+
+cfl		= .95
+
+#		problem parameters
+
+gamma           = 1.4
+rho_ambient     = 1.0
+p_ambient       = 1.0
+u_ambient       = 1.0
+v_ambient       = 1.0
+
+dtmin           = 2.5e-02
+dtmax           = 2.5e-02
+dtinit           = 2.5e-02
+
+vortex_strength	= 5.0
+xctr            = 5.0
+yctr            = 5.0
+
+xmin            = 0.0
+xmax            = 10.0
+ymin            = 0.0
+ymax            = 10.0
+
+nx_subint       = 1
+ny_subint       = 1
+
+geometry        = "cartesian"
+
+xl_boundary_type = "periodic"
+xr_boundary_type = "periodic"
+zl_boundary_type = "periodic"
+zr_boundary_type = "periodic"
+
+smlrho          = 1.e-100
+smallp          = 1.e-100
+smalle          = 1.e-100
+smallt          = 1.e-100
+
+nriem           = 5
+convertToConsvdInMeshInterp   = .true.
+use_steepening  = .false.
+cvisc           = 0.
+eintSwitch     = 0.
+
+plot_var_1 = "dens"
+
+
+## -------------------------------------------------------------##
+##  SWITCHES SPECIFIC TO THE UNSPLIT HYDRO SOLVER               ##
+#	I. INTERPOLATION SCHEME:
+order		= 2      # Interpolation order (first/second/third/fifth order)
+slopeLimiter    = "mc"   # Slope limiters (minmod, mc, vanLeer, hybrid, limited)
+LimitedSlopeBeta= 1.     # Slope parameter for the "limited" slope by Toro
+charLimiting	= .true. # Characteristic limiting vs. Primitive limiting
+
+use_avisc	= .false. # use artificial viscosity (originally for PPM)
+#cvisc		= 0.1     # coefficient for artificial viscosity
+use_flattening	= .false. # use flattening (dissipative) (originally for PPM)
+use_steepening	= .false. # use contact steepening (originally for PPM)
+use_upwindTVD	= .false. # use upwind biased TVD slope for PPM (need nguard=6)
+
+#	II. RIEMANN SOLVERS:
+RiemannSolver	= "Roe"       # Roe, HLL, HLLC, LLF, Marquina
+entropy         = .false.     # Entropy fix for the Roe solver
+
+#	III. STRONG SHOCK HANDELING SCHEME:
+shockDetect	= .false.     # Shock Detect for numerical stability
+## -------------------------------------------------------------##
+
+## ---------------------------------------------------------------##
+##  SWITCHES SPECIFIC TO THE SUPER-TIME-STEPPING (STS) ALGORITHM  ##
+##  NOTE: For details on using STS runtime parameters, please     ##
+##        refer to user's guide (Driver chapter).                 ##
+useSTS                  = .false.
+nstepTotalSTS           = 5
+nuSTS                   = 0.2
+## ---------------------------------------------------------------##

--- a/source/Simulation/SimulationMain/IsentropicVortex/flash.par.pseudoug
+++ b/source/Simulation/SimulationMain/IsentropicVortex/flash.par.pseudoug
@@ -1,0 +1,115 @@
+#  Runtime parameter file for the isentropic vortex problem
+
+#               AMR parameters
+
+lrefine_max     = 3
+lrefine_min     = 3
+refine_var_1     = "dens"
+
+pt_numX	= 10
+pt_numY	= 10
+
+pt_maxPerProc = 100
+
+useParticles = .true.
+
+pt_initialXMin = 0.0
+pt_initialXMax = 10.0
+pt_initialYMin = 0.0
+pt_initialYMax = 10.0
+pt_initialZMin = 0.0
+pt_initialZMax = 10.0
+
+
+#		simulation parameters
+
+basenm          = "isentropic_vortex_"
+log_file        = "isentropic_vortex.log"
+restart         = .false.
+checkpointFileIntervalTime = 0.0
+checkpointFileIntervalStep = 20
+checkpointFileNumber = 0	
+
+nend            = 1000
+tmax            = 10.
+
+#nblockx		= 2
+#nblocky		= 2
+
+cfl		= .95
+
+#		problem parameters
+
+gamma           = 1.4
+rho_ambient     = 1.0
+p_ambient       = 1.0
+u_ambient       = 1.0
+v_ambient       = 1.0
+
+dtmin           = 2.5e-02
+dtmax           = 2.5e-02
+dtinit           = 2.5e-02
+
+vortex_strength	= 5.0
+xctr            = 5.0
+yctr            = 5.0
+
+xmin            = 0.0
+xmax            = 10.0
+ymin            = 0.0
+ymax            = 10.0
+
+nx_subint       = 1
+ny_subint       = 1
+
+geometry        = "cartesian"
+
+xl_boundary_type = "periodic"
+xr_boundary_type = "periodic"
+zl_boundary_type = "periodic"
+zr_boundary_type = "periodic"
+
+smlrho          = 1.e-100
+smallp          = 1.e-100
+smalle          = 1.e-100
+smallt          = 1.e-100
+
+nriem           = 5
+convertToConsvdInMeshInterp   = .true.
+use_steepening  = .false.
+cvisc           = 0.
+eintSwitch     = 0.
+
+plot_var_1 = "dens"
+
+
+## -------------------------------------------------------------##
+##  SWITCHES SPECIFIC TO THE UNSPLIT HYDRO SOLVER               ##
+#	I. INTERPOLATION SCHEME:
+order		= 2      # Interpolation order (first/second/third/fifth order)
+slopeLimiter    = "mc"   # Slope limiters (minmod, mc, vanLeer, hybrid, limited)
+LimitedSlopeBeta= 1.     # Slope parameter for the "limited" slope by Toro
+charLimiting	= .true. # Characteristic limiting vs. Primitive limiting
+
+use_avisc	= .false. # use artificial viscosity (originally for PPM)
+#cvisc		= 0.1     # coefficient for artificial viscosity
+use_flattening	= .false. # use flattening (dissipative) (originally for PPM)
+use_steepening	= .false. # use contact steepening (originally for PPM)
+use_upwindTVD	= .false. # use upwind biased TVD slope for PPM (need nguard=6)
+
+#	II. RIEMANN SOLVERS:
+RiemannSolver	= "Roe"       # Roe, HLL, HLLC, LLF, Marquina
+entropy         = .false.     # Entropy fix for the Roe solver
+
+#	III. STRONG SHOCK HANDELING SCHEME:
+shockDetect	= .false.     # Shock Detect for numerical stability
+## -------------------------------------------------------------##
+
+## ---------------------------------------------------------------##
+##  SWITCHES SPECIFIC TO THE SUPER-TIME-STEPPING (STS) ALGORITHM  ##
+##  NOTE: For details on using STS runtime parameters, please     ##
+##        refer to user's guide (Driver chapter).                 ##
+useSTS                  = .false.
+nstepTotalSTS           = 5
+nuSTS                   = 0.2
+## ---------------------------------------------------------------##


### PR DESCRIPTION
These commits fix intel compiler issue #541 . Problem was that some simulation specific vars (and one in IO_writeParticles) were not initialized). Now particles are not written in checkpoint so the baseline comparison will also change. 

@jared321 Whenever we decide to push it forward, the new baseline file that also need to go with it is here: `/homes/saurabh/master-jenkins-run-result/isentropic_vortex_hdf5_chk_0021`
In my local branch on compute001, the test suite runs successfully with this new baseline.