### PR TITLE
Change commenting style in Config files

### DIFF
--- a/source/Grid/GridSolvers/AmrexHYPRE/Config
+++ b/source/Grid/GridSolvers/AmrexHYPRE/Config
@@ -3,36 +3,36 @@ USESETUPVARS Grid
 #   SETUPERROR AmrexMultigridSolver must be run with AMReX grid only!!!
 #ENDIF
 
-D CHILDORDER paramesh UG multiScalar
+##CHILDORDER paramesh UG multiScalar
 
-D EXCLUSIVE paramesh UG
+##EXCLUSIVE paramesh UG
 
-D Params for amrex multigrid solve
+# Params for amrex multigrid solve
 PARAMETER gr_amrexLs_max_level	INTEGER 1
 PARAMETER gr_amrexLs_ref_ratio	INTEGER 2
 PARAMETER gr_amrexLs_n_cell		INTEGER 32 #128
 PARAMETER gr_amrexLs_max_grid_size	INTEGER 16 #64
 
-D composite solve or level by level?
+D gr_amrexLs_composite_solve  composite solve or level by level?
 PARAMETER gr_amrexLs_composite_solve	BOOLEAN	TRUE
 
-D 1=Poisson 2=ABEC
+D gr_amrexLs_prob_type 1=Poisson 2=ABEC
 PARAMETER gr_amrexLs_prob_type	INTEGER 1
 
-D For MLMG
+# For MLMG
 PARAMETER gr_amrexLs_verbose	INTEGER 2
 PARAMETER gr_amrexLs_cg_verbose	INTEGER 0
 PARAMETER gr_amrexLs_max_iter	INTEGER 100
 
-D number of F-cycles before switching to V.  To do pure V-cycle, set to 0
+D gr_amrexLs_max_fmg_iter number of F-cycles before switching to V.  To do pure V-cycle, set to 0
 PARAMETER gr_amrexLs_max_fmg_iter	INTEGER 0
 PARAMETER gr_amrexLs_linop_maxorder	INTEGER 2
 
-D Do agglomeration on AMR Level 0?
+D gr_amrexLs_agglomeration Do agglomeration on AMR Level 0?
 PARAMETER gr_amrexLs_agglomeration	BOOLEAN TRUE
 
-D Do consolidation?
+D gr_amrexLs_consolidation Do consolidation?
 PARAMETER gr_amrexLs_consolidation	BOOLEAN TRUE
 
-D Variable for solution of Poisson equation
+D phi_variable Variable for solution of Poisson equation
 VARIABLE phi

--- a/source/Grid/GridSolvers/AmrexPetscKsp/Config
+++ b/source/Grid/GridSolvers/AmrexPetscKsp/Config
@@ -3,36 +3,36 @@ USESETUPVARS Grid
 #   SETUPERROR AmrexMultigridSolver must be run with AMReX grid only!!!
 #ENDIF
 
-D CHILDORDER paramesh UG multiScalar
+##CHILDORDER paramesh UG multiScalar
 
-D EXCLUSIVE paramesh UG
+##EXCLUSIVE paramesh UG
 
-D Params for amrex multigrid solve
+# Params for amrex multigrid solve
 PARAMETER gr_amrexLs_max_level	INTEGER 1
 PARAMETER gr_amrexLs_ref_ratio	INTEGER 2
 PARAMETER gr_amrexLs_n_cell		INTEGER 32 #128
 PARAMETER gr_amrexLs_max_grid_size	INTEGER 16 #64
 
-D composite solve or level by level?
+D gr_amrexLs_composite_solve  composite solve or level by level?
 PARAMETER gr_amrexLs_composite_solve	BOOLEAN	TRUE
 
-D 1=Poisson 2=ABEC
+D gr_amrexLs_prob_type 1=Poisson 2=ABEC
 PARAMETER gr_amrexLs_prob_type	INTEGER 1
 
-D For MLMG
+# For MLMG
 PARAMETER gr_amrexLs_verbose	INTEGER 2
 PARAMETER gr_amrexLs_cg_verbose	INTEGER 0
 PARAMETER gr_amrexLs_max_iter	INTEGER 100
 
-D number of F-cycles before switching to V.  To do pure V-cycle, set to 0
+D gr_amrexLs_max_fmg_iter number of F-cycles before switching to V.  To do pure V-cycle, set to 0
 PARAMETER gr_amrexLs_max_fmg_iter	INTEGER 0
 PARAMETER gr_amrexLs_linop_maxorder	INTEGER 2
 
-D Do agglomeration on AMR Level 0?
+D gr_amrexLs_agglomeration Do agglomeration on AMR Level 0?
 PARAMETER gr_amrexLs_agglomeration	BOOLEAN TRUE
 
-D Do consolidation?
+D gr_amrexLs_consolidation Do consolidation?
 PARAMETER gr_amrexLs_consolidation	BOOLEAN TRUE
 
-D Variable for solution of Poisson equation
+D phi_variable Variable for solution of Poisson equation
 VARIABLE phi


### PR DESCRIPTION
We should use
 * `#` for general comments
   - maybe` ##` to 'comment out' stuff
 * `D` _NAME_ to describe the runtime parameter  _NAME_
 * `D` _NAME_`_variable` to describe the VARIABLE _NAME_

The point of using `D ` is that the descriptions are collected
into files setup_params (and setup_variables) at setup time,
for convenient reference later.